### PR TITLE
Update org references

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -1,0 +1,16 @@
+name: Add new issues to the verification team's project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/NOAA-GSL/projects/14
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The entrypoint for the library is intended to be `parser` and should be the only
 
 ```go
 import (
-    "github.com/NOAA-GSL/METstat2json/pkg/parser"
+    "github.com/dtcenter/METstat2json/pkg/parser"
 )
 
 func main() {

--- a/docs/development-notes.md
+++ b/docs/development-notes.md
@@ -4,7 +4,7 @@ This is a parser for MET output files.
 
 ## Approach
 
-The approach is to use a [Go program](https://github.com/NOAA-GSL/METstat2json/blob/main/generator/generator.go) that uses several files from the MET repo (which is versioned by METplus) to generate another GO package that can then be imported to a GO program that can be used for parsing MET output files. The MET output file versions that are supported are v10.0.0 and later.
+The approach is to use a [Go program](https://github.com/dtcenter/METstat2json/blob/main/generator/generator.go) that uses several files from the MET repo (which is versioned by METplus) to generate another GO package that can then be imported to a GO program that can be used for parsing MET output files. The MET output file versions that are supported are v10.0.0 and later.
 
 The file [column defs](https://raw.githubusercontent.com/dtcenter/MET/refs/heads/main_v12.0/data/table_files/met_header_columns_V12.0.txt) as well as met_header_columns_v11.1.0, ...\_v11.0.0, ...\_v10.1.0, and ...\_v10.0.0 are used to get a list of required terms that need to be type defined for eacg respective version. Then several source code files are searched for type conversion statements for those terms. If the type of a term cannot be determined from source code an attempt is made to look up the term in the MET user guide.
 
@@ -35,17 +35,17 @@ These are the src files that are searched...
 
 ... in order to derive column definitions and type information that is used to create the GO packages ...
 
-- [linetypes/v10_0](https://github.com/NOAA-GSL/METstat2json/tree/main/pkg/linetypes/v10_0)
-- [linetypes/v10_1](https://github.com/NOAA-GSL/METstat2json/tree/main/pkg/linetypes/v10_1)
-- [linetypes/v11_0](https://github.com/NOAA-GSL/METstat2json/tree/main/pkg/linetypes/v11_0)
-- [linetypes/v11_0](https://github.com/NOAA-GSL/METstat2json/tree/main/pkg/linetypes/v11_0)
-- [linetypes/v11_1](https://github.com/NOAA-GSL/METstat2json/tree/main/pkg/linetypes/v11_1)
-- [linetypes/v12_0](https://github.com/NOAA-GSL/METstat2json/tree/main/pkg/linetypes/v12_0)
+- [linetypes/v10_0](https://github.com/dtcenter/METstat2json/tree/main/pkg/linetypes/v10_0)
+- [linetypes/v10_1](https://github.com/dtcenter/METstat2json/tree/main/pkg/linetypes/v10_1)
+- [linetypes/v11_0](https://github.com/dtcenter/METstat2json/tree/main/pkg/linetypes/v11_0)
+- [linetypes/v11_0](https://github.com/dtcenter/METstat2json/tree/main/pkg/linetypes/v11_0)
+- [linetypes/v11_1](https://github.com/dtcenter/METstat2json/tree/main/pkg/linetypes/v11_1)
+- [linetypes/v12_0](https://github.com/dtcenter/METstat2json/tree/main/pkg/linetypes/v12_0)
 
 These packages contain the struct definitions, fill functions for each MET line type, and parse routines necessary to convert MET output files into json documents for use in a GSL AVID Couchbase database, according to the AVID Couchbase data schema.
 
 In addition to the "pkg/linetypes/*" packages there are several other local packages, "pkg/parser", "examples/sample_parser", "generator", and "pkg/util".
-The "sample_parser" package demonstrates how to use the [parser](https://github.com/NOAA-GSL/METstat2json/tree/main/pkg/parser) package. The parser is the only package that is required to parse MET output files.
+The "sample_parser" package demonstrates how to use the [parser](https://github.com/dtcenter/METstat2json/tree/main/pkg/parser) package. The parser is the only package that is required to parse MET output files.
 
 ### parser
 

--- a/examples/sample_parser/sample_parser.go
+++ b/examples/sample_parser/sample_parser.go
@@ -12,7 +12,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/NOAA-GSL/METstat2json/pkg/parser"
+	"github.com/dtcenter/METstat2json/pkg/parser"
 )
 
 // dummy function to satisfy the function signature of getExternalDocForId

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -10,7 +10,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/NOAA-GSL/METstat2json/pkg/util"
+	"github.com/dtcenter/METstat2json/pkg/util"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/NOAA-GSL/METstat2json
+module github.com/dtcenter/METstat2json
 
 go 1.23.3
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ retract [v1.0.0, v1.0.4] // Published accidentally
 
 require (
 	github.com/stretchr/testify v1.10.0
-	golang.org/x/text v0.25.0
+	golang.org/x/text v0.26.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/text v0.25.0 h1:qVyWApTSYLk/drJRO5mDlNYskwQznZmkpV2c8q9zls4=
-golang.org/x/text v0.25.0/go.mod h1:WEdwpYrmk1qmdHvhkSTNPm3app7v4rsT8F2UD6+VHIA=
+golang.org/x/text v0.26.0 h1:P42AVeLghgTYr4+xUnTRKDMqpar+PtX7KWuNQL21L8M=
+golang.org/x/text v0.26.0/go.mod h1:QK15LZJUUQVJxhz7wXgxSy/CJaTFjd0G+YLonydOVQA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -9,12 +9,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/NOAA-GSL/METstat2json/pkg/linetypes/v10_0"
-	"github.com/NOAA-GSL/METstat2json/pkg/linetypes/v10_1"
-	"github.com/NOAA-GSL/METstat2json/pkg/linetypes/v11_0"
-	"github.com/NOAA-GSL/METstat2json/pkg/linetypes/v11_1"
-	"github.com/NOAA-GSL/METstat2json/pkg/linetypes/v12_0"
-	"github.com/NOAA-GSL/METstat2json/pkg/util"
+	"github.com/dtcenter/METstat2json/pkg/linetypes/v10_0"
+	"github.com/dtcenter/METstat2json/pkg/linetypes/v10_1"
+	"github.com/dtcenter/METstat2json/pkg/linetypes/v11_0"
+	"github.com/dtcenter/METstat2json/pkg/linetypes/v11_1"
+	"github.com/dtcenter/METstat2json/pkg/linetypes/v12_0"
+	"github.com/dtcenter/METstat2json/pkg/util"
 )
 
 /*

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -20,11 +20,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/NOAA-GSL/METstat2json/pkg/linetypes/v10_0"
-	"github.com/NOAA-GSL/METstat2json/pkg/linetypes/v10_1"
-	"github.com/NOAA-GSL/METstat2json/pkg/linetypes/v11_0"
-	"github.com/NOAA-GSL/METstat2json/pkg/linetypes/v11_1"
-	"github.com/NOAA-GSL/METstat2json/pkg/linetypes/v12_0"
+	"github.com/dtcenter/METstat2json/pkg/linetypes/v10_0"
+	"github.com/dtcenter/METstat2json/pkg/linetypes/v10_1"
+	"github.com/dtcenter/METstat2json/pkg/linetypes/v11_0"
+	"github.com/dtcenter/METstat2json/pkg/linetypes/v11_1"
+	"github.com/dtcenter/METstat2json/pkg/linetypes/v12_0"
 )
 
 var testdataDir = ""


### PR DESCRIPTION
This change updates org references, where appropriate, from NOAA-GSL to dtcenter, adds a new CI workflow to ensure issues appear on the team's project board, and updates our dependencies.