### PR TITLE
Implement validtypes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version-file: "go.mod"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,20 @@ jobs:
           go-version-file: "go.mod"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+      - name: Build
+        run: go build -v ./...
+      - name: Test
+        run: go test -short -v -shuffle=on -cover ./...
+      - name: Test for flaky tests
+        run: go test -short -count 100 ./...
+      - name: Test for race conditions
+        run: go test -short -race ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,6 +85,7 @@ linters:
     # Test-related checks.
     - usetesting
     - testableexamples
+    - testifylint
     - thelper
     - tparallel
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dtcenter/METstat2json
 
-go 1.23.3
+go 1.24.0
 
 retract [v1.0.0, v1.0.4] // Published accidentally
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -129,6 +129,9 @@ func ReadJsonFromGzipFile(filename string) (map[string]interface{}, error) {
 }
 
 func TestGetMissingExternalDocForId(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	headerLine := "VERSION MODEL DESC FCST_LEAD FCST_VALID_BEG  FCST_VALID_END  OBS_LEAD OBS_VALID_BEG   OBS_VALID_END   FCST_VAR  FCST_UNITS FCST_LEV OBS_VAR   OBS_UNITS OBS_LEV  OBTYPE VX_MASK INTERP_MTHD INTERP_PNTS FCST_THRESH OBS_THRESH COV_THRESH ALPHA LINE_TYPE"
 	dataLine := "V12.0.0 FCST  NA   120000    20120409_120000 20120409_120000 000000   20120409_113000 20120409_123000 UGRD_VGRD m/s        Z10      UGRD_VGRD NA        Z10      ADPSFC LAND_L0 NEAREST     1           NA          NA         NA         NA    VAL1L2    4114    0.022881     -0.055846      -0.23975       0.11316       1.40894     2.39774     6.07755      1.35071    2.1488    4114           12.11241   65.18733  6744.28012"
 	fName := "grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_900000L_20241104_180000V.stat"
@@ -140,6 +143,9 @@ func TestGetMissingExternalDocForId(t *testing.T) {
 }
 
 func TestUnsupportedVersion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	headerLine := "VERSION MODEL DESC FCST_LEAD FCST_VALID_BEG FCST_VALID_END OBS_LEAD OBS_VALID_BEG OBS_VALID_END FCST_VAR FCST_UNITS FCST_LEV OBS_VAR OBS_UNITS OBS_LEV OBTYPE VX_MASK INTERP_MTHD INTERP_PNTS FCST_THRESH OBS_THRESH COV_THRESH ALPHA LINE_TYPE"
 	dataLine := "V9.0 FCST NA 120000 20120409_120000 20120409_120000 000000 20120409_113000 20120409_123000 UGRD_VGRD m/s Z10 UGRD_VGRD NA Z10 ADPSFC LAND_L0 NEAREST 1 NA NA NA NA VAL1L2 4114 0.022881 -0.055846 -0.23975 0.11316 1.40894 2.39774 6.07755 1.35071 2.1488 4114 12.11241 65.18733 6744.28012"
 	fName := "grid_stat_NO_WEIGHT_240000L_20120410_000000V.stat"
@@ -154,6 +160,9 @@ func TestUnsupportedVersion(t *testing.T) {
 }
 
 func TestGetExistingExternalDocForId(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	headerLine := "VERSION MODEL DESC FCST_LEAD FCST_VALID_BEG  FCST_VALID_END  OBS_LEAD OBS_VALID_BEG   OBS_VALID_END   FCST_VAR  FCST_UNITS FCST_LEV OBS_VAR   OBS_UNITS OBS_LEV  OBTYPE VX_MASK INTERP_MTHD INTERP_PNTS FCST_THRESH OBS_THRESH COV_THRESH ALPHA LINE_TYPE"
 	dataLine := "V12.0.0 FCST  NA   120000    20120409_120000 20120409_120000 000000   20120409_113000 20120409_123000 UGRD_VGRD m/s        Z10      UGRD_VGRD NA        Z10      ADPSFC LAND_L0 NEAREST     1           NA          NA         NA         NA    VAL1L2    4114    0.022881     -0.055846      -0.23975       0.11316       1.40894     2.39774     6.07755      1.35071    2.1488    4114           12.11241   65.18733  6744.28012"
 	fName := "grid_stat_GFS_TMP_vs_ANLYS_TMP_Z2_900000L_20241104_180000V.stat"
@@ -165,6 +174,9 @@ func TestGetExistingExternalDocForId(t *testing.T) {
 }
 
 func TestParseVAL1L2(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	/* two of these data lines (dataLine and dataLine2) are the same. Only one of them should show up in the doc. The dataLine3 and dataLine4 only differ by their desc.*/
 	headerLine := "VERSION MODEL DESC FCST_LEAD FCST_VALID_BEG  FCST_VALID_END  OBS_LEAD OBS_VALID_BEG   OBS_VALID_END   FCST_VAR  FCST_UNITS FCST_LEV OBS_VAR   OBS_UNITS OBS_LEV  OBTYPE VX_MASK INTERP_MTHD INTERP_PNTS FCST_THRESH OBS_THRESH COV_THRESH ALPHA LINE_TYPE"
 	dataLine := "V12.0.0 FCST  NA   120000    20120409_120000 20120409_120000 000000   20120409_113000 20120409_123000 UGRD_VGRD m/s        Z10      UGRD_VGRD NA        Z10      ADPSFC LAND_L0 NEAREST     1           NA          NA         NA         NA    VAL1L2    4114    0.022881     -0.055846      -0.23975       0.11316       1.40894     2.39774     6.07755      1.35071    2.1488    4114           12.11241   65.18733  6744.28012"
@@ -206,7 +218,7 @@ func TestParseVAL1L2(t *testing.T) {
 	}
 
 	assert.NotNil(t, parsedDoc)
-	assert.Equal(t, 3, len(parsedDoc), "expected 3 but got %d", len(parsedDoc)) // two top level elements
+	assert.Len(t, parsedDoc, 3, "expected 3 but got %d", len(parsedDoc)) // two top level elements
 	doc0 := doc["MET:DD:MET:test:V12.0.0:FCST:1333972800:1333972800:000000:1333971000:1333974600:UGRD_VGRD:m/s:Z10:UGRD_VGRD:Z10:ADPSFC:LAND_L0:NEAREST:1:VAL1L2"].(map[string]interface{})
 	doc2 := doc["MET:DD:MET:test:V12.0.0:FCST:this_is_a_:1333972800:1333972800:000000:1333971000:1333974600:UGRD_VGRD:m/s:Z10:UGRD_VGRD:Z10:ADPSFC:LMV:NEAREST:1:VAL1L2"].(map[string]interface{})
 	doc0Data := doc0["data"].(map[string]v12_0.STAT_VAL1L2)
@@ -237,6 +249,9 @@ func TestParseVAL1L2(t *testing.T) {
 This test tests a data field dataKey.
 */
 func TestParseMODE_OBJ(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	headerLine := "VERSION MODEL N_VALID GRID_RES DESC FCST_LEAD FCST_VALID      FCST_ACCUM OBS_LEAD OBS_VALID       OBS_ACCUM FCST_RAD FCST_THR OBS_RAD OBS_THR FCST_VAR FCST_UNITS FCST_LEV OBS_VAR OBS_UNITS OBS_LEV OBTYPE FIELD  TOTAL FY_OY FY_ON FN_OY FN_ON BASER   FMEAN    ACC     FBIAS  PODY       PODN    POFD     FAR     CSI        GSS       HK        HSS       ODDS      LODDS   ORSS     EDS      SEDS     EDI      SEDI     BAGSS"
 	dataLine := "V12.0.0 FCST  26026   9        NA   300000    20120410_180000 060000     120000   20050807_120000 120000    2        >=5.0    2       >=5.0   APCP_06  kg/m^2     A6       OBS     None      Surface STAGE4    RAW 26026    47  1356  5898 18725 0.22843 0.053908 0.72128 0.236  0.0079058  0.93247 0.067527 0.9665  0.0064375  -0.039178 -0.059621 -0.08155  0.11004   -2.2069 -0.80173 -0.53249 -0.3039  -0.28465 -0.28988 -0.11236"
 	dataLine2 := "V12.0.0 FCST  26026   9        this_is_a_long_description   300000    20120410_180000 060000     120000   20050807_120000 120000    2        >=5.0    2       >=5.0   APCP_06  kg/m^2     A6       OBS     None      Surface STAGE4 OBJECT 26026     4  1315  6322 18385 0.24306 0.05068  0.70656 0.2085 0.00063231 0.93325 0.066751 0.99697 0.00052349 -0.043249 -0.066119 -0.090409 0.0088459 -4.7278 -0.98246 -0.67783 -0.49927 -0.46256 -0.46613 -0.13686"
@@ -264,7 +279,7 @@ func TestParseMODE_OBJ(t *testing.T) {
 	}
 
 	assert.NotNil(t, parsedDoc)
-	assert.Equal(t, 2, len(parsedDoc), "expected 3 but got %d", len(parsedDoc)) // two top level elements
+	assert.Len(t, parsedDoc, 2, "expected 3 but got %d", len(parsedDoc)) // two top level elements
 	doc0 := doc["MET:DD:MET:test:V12.0.0:FCST:26026:9:20120410_180000:060000:120000:20050807_120000:120000:2:>=5.0:2:>=5.0:APCP_06:kg/m^2:A6:OBS:None:Surface:STAGE4"].(map[string]interface{})
 	doc2 := doc["MET:DD:MET:test:V12.0.0:FCST:26026:9:this_is_a_:20120410_180000:060000:120000:20050807_120000:120000:2:>=5.0:2:>=5.0:APCP_06:kg/m^2:A6:OBS:None:Surface:STAGE4"].(map[string]interface{})
 	doc0Data := doc0["data"].(map[string]v12_0.MODE_CTS)
@@ -290,6 +305,9 @@ func TestParseMODE_OBJ(t *testing.T) {
 
 // V11.1.0  ./MODE_compref/20241201-13/mode_compref_010000L_20241201_130000V_000000A_R1_T2_obj.txt
 func TestParseMODE_OBJ_V11_1_0(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	headerLine := "VERSION MODEL N_VALID GRID_RES DESC FCST_LEAD FCST_VALID FCST_ACCUM OBS_LEAD OBS_VALID OBS_ACCUM FCST_RAD FCST_THR OBS_RAD OBS_THR FCST_VAR FCST_UNITS FCST_LEV OBS_VAR OBS_UNITS OBS_LEV OBTYPE OBJECT_ID OBJECT_CAT CENTROID_X CENTROID_Y CENTROID_LAT CENTROID_LON AXIS_ANG LENGTH WIDTH AREA AREA_THRESH CURVATURE CURVATURE_X CURVATURE_Y COMPLEXITY INTENSITY_10 INTENSITY_25 INTENSITY_50 INTENSITY_75 INTENSITY_90 INTENSITY_95 INTENSITY_SUM CENTROID_DIST BOUNDARY_DIST CONVEX_HULL_DIST ANGLE_DIFF ASPECT_DIFF AREA_RATIO INTERSECTION_AREA UNION_AREA SYMMETRIC_DIFF INTERSECTION_OVER_AREA CURVATURE_RATIO COMPLEXITY_RATIO PERCENTILE_INTENSITY_RATIO INTEREST"
 	dataLine := "V11.1.0 HRRR_OPS 656523 3 E_CONUS 010000 20241201_130000 000000 000000 20241201_125839 000000 1 >=30 1 >=30 REFC dB L0 REFC dB R1 MRMS F001 CF000 1191.36111 848.40278 46.59842 -86.11741 -63.68914 18.78477 7.15138 39 38 1638.70076 1725.16372 1359.51523 0.53012 30.575 30.90625 31.75 34.375 39.1125 40.2 1286.1875 NA NA NA NA NA NA NA NA NA NA NA NA NA NA"
 	dataLine2 := "V11.1.0 HRRR_OPS 656523 3 E_CONUS 010000 20241201_130000 000000 000000 20241201_125839 000000 1 >=30 1 >=30 REFC dB L0 REFC dB R1 MRMS F002 CF000 1195.86842 834.47368 46.21429 -86.01102 -74.49824 9.74167 4.12176 24 24 1643.5243 1675.00455 1421.96375 0.15789 30.89375 31.4375 31.875 32.73438 33.73125 33.85625 770.875 NA NA NA NA NA NA NA NA NA NA NA NA NA NA"
@@ -318,20 +336,24 @@ func TestParseMODE_OBJ_V11_1_0(t *testing.T) {
 	}
 
 	assert.NotNil(t, parsedDoc)
-	assert.Equal(t, 1, len(parsedDoc), "expected 1 but got %d", len(parsedDoc)) // two top level elements
+	assert.Len(t, parsedDoc, 1, "expected 1 but got %d", len(parsedDoc)) // two top level elements
 	tmpDoc := doc["MET:DD:MET:test:V11.1.0:HRRR_OPS:656523:3:E_CONUS:20241201_130000:000000:000000:20241201_125839:000000:1:>=30:1:>=30:REFC:dB:L0:REFC:dB:R1:MRMS"].(map[string]interface{})
 	data := tmpDoc["data"].(map[string]v11_1.MODE_OBJ)
 	elem1Data := data["010000_F001"]
 	elem2Data := data["010000_F002"]
-	assert.Equal(t, elem1Data.CENTROID_X, 1191.36111, "expected data[\"010000_F001\"].CENTROID_X to be 1191.36111")
-	assert.Equal(t, elem2Data.CENTROID_X, 1195.86842, "expected data[\"010000_F002\"].CENTROID_X to be 1195.86842")
-	assert.Equal(t, elem1Data.CENTROID_Y, 848.40278, "expected data[\"010000_F001\"].CENTROID_Y to be 848.40278")
-	assert.Equal(t, elem2Data.CENTROID_Y, 834.47368, "expected data[\"010000_F002\"].CENTROID_Y to be 834.47368")
-	assert.Equal(t, elem1Data.CENTROID_LAT, 46.59842, "expected data[\"010000_F001\"].CENTROID_LAT to be 46.59842")
-	assert.Equal(t, elem2Data.CENTROID_LAT, 46.21429, "expected data[\"010000_F002\"].CENTROID_LAT to be 46.21429")
+	tolerance := 0.00001
+	assert.InDelta(t, 1191.36111, elem1Data.CENTROID_X, tolerance, "expected data[\"010000_F001\"].CENTROID_X to be 1191.36111")
+	assert.InDelta(t, 1195.86842, elem2Data.CENTROID_X, tolerance, "expected data[\"010000_F002\"].CENTROID_X to be 1195.86842")
+	assert.InDelta(t, 848.40278, elem1Data.CENTROID_Y, tolerance, "expected data[\"010000_F001\"].CENTROID_Y to be 848.40278")
+	assert.InDelta(t, 834.47368, elem2Data.CENTROID_Y, tolerance, "expected data[\"010000_F002\"].CENTROID_Y to be 834.47368")
+	assert.InDelta(t, 46.59842, elem1Data.CENTROID_LAT, tolerance, "expected data[\"010000_F001\"].CENTROID_LAT to be 46.59842")
+	assert.InDelta(t, 46.21429, elem2Data.CENTROID_LAT, tolerance, "expected data[\"010000_F002\"].CENTROID_LAT to be 46.21429")
 }
 
 func TestModeFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	var doc map[string]interface{}
 	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
@@ -390,6 +412,9 @@ func TestModeFile(t *testing.T) {
 }
 
 func TestMC_PCP_File(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	var doc map[string]interface{}
 	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
@@ -437,6 +462,9 @@ func TestMC_PCP_File(t *testing.T) {
 }
 
 func TestTC_CTS_File(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	var doc map[string]interface{}
 	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
@@ -484,6 +512,9 @@ func TestTC_CTS_File(t *testing.T) {
 }
 
 func TestMC_CTS_File(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	var doc map[string]interface{}
 	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
@@ -533,6 +564,9 @@ func TestMC_CTS_File(t *testing.T) {
 // tcst file
 // testdata/tcstfiles/al022013_interp12_fill.tcst
 func Test_TCST_File(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	var doc map[string]interface{}
 	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
@@ -582,6 +616,9 @@ func Test_TCST_File(t *testing.T) {
 // tc_data file
 // /ttc_data/CMC/2024081306/tc_pairs_ep05.dat_PROBRIRW.tcst
 func Test_TCDATA_File(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	var doc map[string]interface{}
 	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
@@ -630,6 +667,9 @@ func Test_TCDATA_File(t *testing.T) {
 
 // ./tc_data/GFSO/2023060912/tc_pairs_al02.dat.tcst
 func Test_TCDATA_File_V10_1_1_NA_VALS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	var doc map[string]interface{}
 	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
@@ -679,6 +719,9 @@ func Test_TCDATA_File_V10_1_1_NA_VALS(t *testing.T) {
 
 // V10.1.1  ./tc_data/GFSO/2023091600/tc_pairs_al13.dat.tcst
 func Test_TCDATA_File_V10_1_1(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	var doc map[string]interface{}
 	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
@@ -727,6 +770,9 @@ func Test_TCDATA_File_V10_1_1(t *testing.T) {
 
 // tcpairs test
 func Test_TCPAIRS_File(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	var doc map[string]interface{}
 	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
@@ -774,6 +820,9 @@ func Test_TCPAIRS_File(t *testing.T) {
 }
 
 func TestMC_SAL1L2_File(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	var doc map[string]interface{}
 	tmpDir := t.TempDir()
 	dir, err := getTestDataDir()
@@ -821,6 +870,9 @@ func TestMC_SAL1L2_File(t *testing.T) {
 }
 
 func TestParseRegressionSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	var doc map[string]interface{}
 	var err error
 	tmpDir := t.TempDir()
@@ -893,6 +945,9 @@ func TestParseRegressionSuite(t *testing.T) {
 }
 
 func TestParseG2G_v12_Suite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	var doc map[string]interface{}
 	var err error
 	tmpDir := t.TempDir()
@@ -973,6 +1028,9 @@ func TestParseG2G_v12_Suite(t *testing.T) {
 }
 
 func TestParse_tc_data_Suite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	var doc map[string]interface{}
 	var err error
 	tmpDir := t.TempDir()
@@ -1053,6 +1111,9 @@ func TestParse_tc_data_Suite(t *testing.T) {
 }
 
 func TestParse_tcst_Suite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	var doc map[string]interface{}
 	var err error
 	tmpDir := t.TempDir()
@@ -1137,6 +1198,9 @@ func TestParse_tcst_Suite(t *testing.T) {
 }
 
 func TestParse_textfiles_Suite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration tests in short mode")
+	}
 	var doc map[string]interface{}
 	var err error
 	tmpDir := t.TempDir()

--- a/pkg/validtypes/validtypes.go
+++ b/pkg/validtypes/validtypes.go
@@ -51,7 +51,7 @@ func (vi ValidInt) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json.Unmarshaler.
 // It treats JSON strings "NA" and "null" as a null/invalid value.
-// This superseeds UnmarshalText for JSON input.
+// This supersedes UnmarshalText for JSON input.
 func (vi *ValidInt) UnmarshalJSON(data []byte) error {
 	s := string(data)
 	if s == "null" || s == `"NA"` {
@@ -143,7 +143,7 @@ func (vf ValidFloat) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json.Unmarshaler.
 // It treats JSON strings "NA" and "null" as a null/invalid value.
-// This superseeds UnmarshalText for JSON input.
+// This supersedes UnmarshalText for JSON input.
 func (vf *ValidFloat) UnmarshalJSON(data []byte) error {
 	s := string(data)
 	if s == "null" || s == `"NA"` {
@@ -244,7 +244,7 @@ func (vs ValidString) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json.Unmarshaler.
 // It treats JSON strings "NA" and "null" as a null/invalid value.
-// This superseeds UnmarshalText for JSON input.
+// This supersedes UnmarshalText for JSON input.
 func (vs *ValidString) UnmarshalJSON(data []byte) error {
 	s := string(data)
 	if s == "null" || s == `"NA"` {

--- a/pkg/validtypes/validtypes.go
+++ b/pkg/validtypes/validtypes.go
@@ -67,6 +67,25 @@ func (vi *ValidInt) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// UnmarshalText sets ValidInt from text values (i.e. stat file input)
+// It treats "NA" and empty strings as a null/invalid value.
+func (vi *ValidInt) UnmarshalText(text []byte) error {
+	s := string(text)
+	if s == "" || s == "NA" {
+		vi.Reset()
+		return nil
+	}
+
+	val, err := strconv.Atoi(s)
+	if err != nil {
+		vi.Reset()
+		return err
+	}
+
+	vi.Set(val)
+	return nil
+}
+
 // String returns string representation.
 func (vi ValidInt) String() string {
 	if !vi.Valid {
@@ -135,6 +154,25 @@ func (vf *ValidFloat) UnmarshalJSON(data []byte) error {
 
 	vf.Value = value
 	vf.Valid = true
+	return nil
+}
+
+// UnmarshalText sets ValidFloat from text values (i.e. stat file input)
+// It treats "NA" and empty strings as a null/invalid value.
+func (vf *ValidFloat) UnmarshalText(text []byte) error {
+	s := string(text)
+	if s == "" || s == "NA" {
+		vf.Reset()
+		return nil
+	}
+
+	val, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		vf.Reset()
+		return err
+	}
+
+	vf.Set(val)
 	return nil
 }
 
@@ -216,6 +254,19 @@ func (vs *ValidString) UnmarshalJSON(data []byte) error {
 
 	vs.Value = value
 	vs.Valid = true
+	return nil
+}
+
+// UnmarshalText sets ValidString from text values (i.e. stat file input)
+// It treats "NA" and empty strings as a null/invalid value.
+func (vs *ValidString) UnmarshalText(text []byte) error {
+	s := string(text)
+	if s == "" || s == "NA" {
+		vs.Reset()
+		return nil
+	}
+
+	vs.Set(s)
 	return nil
 }
 

--- a/pkg/validtypes/validtypes.go
+++ b/pkg/validtypes/validtypes.go
@@ -145,3 +145,84 @@ func (vf ValidFloat) String() string {
 	}
 	return strconv.FormatFloat(vf.Value, 'f', -1, 64)
 }
+
+// ValidString represents a string that tracks whether it has been explicitly set.
+// The zero value of ValidString is when Valid=false. ValidString.IsZero is used as an easy
+// way to detect that the ValidString hasn't been explicitly set.
+// It treats "NA" as an invalid/unset value.
+// Fields that are unset can be omitted when marshalling to JSON by using the omitzero tag.
+type ValidString struct {
+	Value string
+	Valid bool
+}
+
+// NewValidString creates a ValidString with a value.
+// It treats "NA" as an invalid value.
+func NewValidString(value string) ValidString {
+	if value == "NA" {
+		return ValidString{}
+	}
+	return ValidString{Value: value, Valid: true}
+}
+
+// Set assigns a value and marks it as valid.
+// It treats "NA" as a signal to reset the value to its invalid state.
+func (vs *ValidString) Set(value string) {
+	if value == "NA" {
+		vs.Reset()
+		return
+	}
+	vs.Value = value
+	vs.Valid = true
+}
+
+// Get returns the underlying value and validity.
+func (vs ValidString) Get() (string, bool) {
+	return vs.Value, vs.Valid
+}
+
+// IsZero is used by omitzero, and returns true if the value is not valid.
+func (vs ValidString) IsZero() bool {
+	return !vs.Valid
+}
+
+// Reset marks the value as invalid.
+func (vs *ValidString) Reset() {
+	vs.Valid = false
+	vs.Value = ""
+}
+
+// MarshalJSON implements json.Marshaler.
+func (vs ValidString) MarshalJSON() ([]byte, error) {
+	if !vs.Valid {
+		return []byte("null"), nil
+	}
+	return json.Marshal(vs.Value)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+// It treats a JSON string "NA" as a null/invalid value.
+func (vs *ValidString) UnmarshalJSON(data []byte) error {
+	s := string(data)
+	if s == "null" || s == `"NA"` {
+		vs.Reset()
+		return nil
+	}
+
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+
+	vs.Value = value
+	vs.Valid = true
+	return nil
+}
+
+// String returns string representation.
+func (vs ValidString) String() string {
+	if !vs.Valid {
+		return ""
+	}
+	return vs.Value
+}

--- a/pkg/validtypes/validtypes.go
+++ b/pkg/validtypes/validtypes.go
@@ -50,10 +50,12 @@ func (vi ValidInt) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
+// It treats JSON strings "NA" and "null" as a null/invalid value.
+// This superseeds UnmarshalText for JSON input.
 func (vi *ValidInt) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" {
-		vi.Valid = false
-		vi.Value = 0
+	s := string(data)
+	if s == "null" || s == `"NA"` {
+		vi.Reset()
 		return nil
 	}
 
@@ -140,10 +142,12 @@ func (vf ValidFloat) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
+// It treats JSON strings "NA" and "null" as a null/invalid value.
+// This superseeds UnmarshalText for JSON input.
 func (vf *ValidFloat) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" {
-		vf.Valid = false
-		vf.Value = 0.0
+	s := string(data)
+	if s == "null" || s == `"NA"` {
+		vf.Reset()
 		return nil
 	}
 
@@ -239,7 +243,8 @@ func (vs ValidString) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-// It treats a JSON string "NA" as a null/invalid value.
+// It treats JSON strings "NA" and "null" as a null/invalid value.
+// This superseeds UnmarshalText for JSON input.
 func (vs *ValidString) UnmarshalJSON(data []byte) error {
 	s := string(data)
 	if s == "null" || s == `"NA"` {

--- a/pkg/validtypes/validtypes.go
+++ b/pkg/validtypes/validtypes.go
@@ -43,7 +43,7 @@ func (vi *ValidInt) Reset() {
 
 // MarshalJSON implements json.Marshaler.
 func (vi ValidInt) MarshalJSON() ([]byte, error) {
-	if !vi.Valid {
+	if !vi.Valid { // Only called when the omitzero tag isn't used
 		return []byte("null"), nil
 	}
 	return json.Marshal(vi.Value)
@@ -73,4 +73,75 @@ func (vi ValidInt) String() string {
 		return ""
 	}
 	return strconv.Itoa(vi.Value)
+}
+
+// ValidFloat represents a float64 that tracks whether it has been explicitly set.
+// The zero value of ValidFloat is when Valid=false. ValidFloat.IsZero is used as an easy
+// way to detect that the ValidFloat hasn't been explicitly set.
+// Fields that are unset, can be omitted when marshalling to JSON by using the omitzero tag
+type ValidFloat struct {
+	Value float64
+	Valid bool
+}
+
+// NewValidFloat creates a ValidFloat with a value.
+func NewValidFloat(value float64) ValidFloat {
+	return ValidFloat{Value: value, Valid: true}
+}
+
+// Set assigns a value and marks it as valid.
+func (vf *ValidFloat) Set(value float64) {
+	vf.Value = value
+	vf.Valid = true
+}
+
+// Get returns the underlying value and validity.
+func (vf ValidFloat) Get() (float64, bool) {
+	return vf.Value, vf.Valid
+}
+
+// IsZero is used by omitzero, and returns true if the value is not valid.
+func (vf ValidFloat) IsZero() bool {
+	return !vf.Valid
+}
+
+// Reset marks the value as invalid.
+func (vf *ValidFloat) Reset() {
+	vf.Valid = false
+	vf.Value = 0.0
+}
+
+// MarshalJSON implements json.Marshaler.
+func (vf ValidFloat) MarshalJSON() ([]byte, error) {
+	if !vf.Valid { // Only called when the omitzero tag isn't used
+		return []byte("null"), nil
+	}
+
+	return json.Marshal(vf.Value)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (vf *ValidFloat) UnmarshalJSON(data []byte) error {
+	if data == nil || string(data) == "null" {
+		vf.Valid = false
+		vf.Value = 0.0
+		return nil
+	}
+
+	var value float64
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+
+	vf.Value = value
+	vf.Valid = true
+	return nil
+}
+
+// String returns string representation.
+func (vf ValidFloat) String() string {
+	if !vf.Valid {
+		return ""
+	}
+	return strconv.FormatFloat(vf.Value, 'f', -1, 64)
 }

--- a/pkg/validtypes/validtypes.go
+++ b/pkg/validtypes/validtypes.go
@@ -1,4 +1,4 @@
-package trial
+package validtypes
 
 import (
 	"encoding/json"

--- a/pkg/validtypes/validtypes.go
+++ b/pkg/validtypes/validtypes.go
@@ -122,7 +122,7 @@ func (vf ValidFloat) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements json.Unmarshaler.
 func (vf *ValidFloat) UnmarshalJSON(data []byte) error {
-	if data == nil || string(data) == "null" {
+	if string(data) == "null" {
 		vf.Valid = false
 		vf.Value = 0.0
 		return nil

--- a/pkg/validtypes/validtypes.go
+++ b/pkg/validtypes/validtypes.go
@@ -1,0 +1,76 @@
+package trial
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// ValidInt represents an int that tracks whether it has been explicitly set.
+// The zero value of ValidInt is when Valid=false. ValidInt.IsZero is used as an easy
+// way to detect that the ValidInt hasn't been explicitly set.
+// Fields that are unset, can be omitted when marshalling to JSON by using the omitzero tag
+type ValidInt struct {
+	Value int
+	Valid bool
+}
+
+// NewValidInt creates a ValidInt with a value.
+func NewValidInt(value int) ValidInt {
+	return ValidInt{Value: value, Valid: true}
+}
+
+// Set assigns a value and marks it as valid.
+func (vi *ValidInt) Set(value int) {
+	vi.Value = value
+	vi.Valid = true
+}
+
+// Get returns the underlying value and validity.
+func (vi ValidInt) Get() (int, bool) {
+	return vi.Value, vi.Valid
+}
+
+// IsZero is used by omitzero, and returns true if the value is not valid.
+func (vi ValidInt) IsZero() bool {
+	return !vi.Valid
+}
+
+// Reset marks the value as invalid.
+func (vi *ValidInt) Reset() {
+	vi.Valid = false
+	vi.Value = 0
+}
+
+// MarshalJSON implements json.Marshaler.
+func (vi ValidInt) MarshalJSON() ([]byte, error) {
+	if !vi.Valid {
+		return []byte("null"), nil
+	}
+	return json.Marshal(vi.Value)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (vi *ValidInt) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		vi.Valid = false
+		vi.Value = 0
+		return nil
+	}
+
+	var value int
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+
+	vi.Value = value
+	vi.Valid = true
+	return nil
+}
+
+// String returns string representation.
+func (vi ValidInt) String() string {
+	if !vi.Valid {
+		return ""
+	}
+	return strconv.Itoa(vi.Value)
+}

--- a/pkg/validtypes/validtypes_test.go
+++ b/pkg/validtypes/validtypes_test.go
@@ -1,0 +1,286 @@
+package trial
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidIntIsZero confirms that IsZero behaves as expected.
+func TestValidInt_IsZero(t *testing.T) {
+	testCases := []struct {
+		name     string
+		action   func(vi *ValidInt)
+		expected bool
+	}{
+		{
+			name:     "Unset ValidInt should be zero",
+			action:   func(vi *ValidInt) {},
+			expected: true,
+		},
+		{
+			name:     "Set to 0 should NOT be zero",
+			action:   func(vi *ValidInt) { vi.Set(0) },
+			expected: false,
+		},
+		{
+			name:     "Set to non-zero should NOT be zero",
+			action:   func(vi *ValidInt) { vi.Set(42) },
+			expected: false,
+		},
+		{
+			name: "Reset should be zero",
+			action: func(vi *ValidInt) {
+				vi.Set(100) // Set to a value first
+				vi.Reset()
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var vi ValidInt
+			tc.action(&vi)
+			assert.Equal(t, tc.expected, vi.IsZero())
+		})
+	}
+}
+
+// TestValidIntMarshal tests marshaling ValidInt with different JSON tags
+func TestValidInt_MarshalJSON(t *testing.T) {
+	type OmitzeroData struct {
+		Field1 ValidInt `json:"FIELD1,omitzero"`
+		Field2 ValidInt `json:"FIELD2,omitzero"`
+		Field3 ValidInt `json:"FIELD3,omitzero"`
+		Field4 ValidInt `json:"FIELD4,omitzero"`
+	}
+	type OmitemptyData struct {
+		Field1 ValidInt `json:"FIELD1,omitempty"`
+		Field2 ValidInt `json:"FIELD2,omitempty"`
+		Field3 ValidInt `json:"FIELD3,omitempty"`
+		Field4 ValidInt `json:"FIELD4,omitempty"`
+	}
+	testCases := []struct {
+		name         string
+		setupData    func() interface{}
+		expectedJSON string
+	}{
+		{
+			name: "omitzero tag",
+			setupData: func() interface{} {
+				sd := OmitzeroData{}
+				sd.Field1.Set(1)
+				sd.Field2.Set(0)
+				sd.Field4.Set(5)
+				// Field3 remains unset
+				return sd
+			},
+			expectedJSON: `{"FIELD1":1,"FIELD2":0,"FIELD4":5}`,
+		},
+		{
+			name: "omitempty tag",
+			setupData: func() interface{} {
+				sd := OmitemptyData{}
+				sd.Field1.Set(1)
+				sd.Field2.Set(0)
+				sd.Field4.Set(5)
+				// Field3 remains unset
+				return sd
+			},
+			expectedJSON: `{"FIELD1":1,"FIELD2":0,"FIELD3":null,"FIELD4":5}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := tc.setupData()
+			jsonData, err := json.Marshal(data)
+			require.NoError(t, err, "Failed to marshal JSON")
+
+			jsonStr := string(jsonData)
+			t.Logf("Generated JSON: %s", jsonStr)
+			assert.JSONEq(t, tc.expectedJSON, jsonStr)
+		})
+	}
+}
+
+// TestValidIntUnmarshal tests unmarshaling JSON into ValidInt fields
+func TestValidInt_UnmarshalJSON(t *testing.T) {
+	type SomeData struct {
+		Field1 ValidInt `json:"FIELD1"`
+		Field2 ValidInt `json:"FIELD2"`
+		Field3 ValidInt `json:"FIELD3"`
+		Field4 ValidInt `json:"FIELD4"`
+	}
+
+	testCases := []struct {
+		name      string
+		jsonData  string
+		expected  SomeData
+		expectErr bool
+	}{
+		{
+			name:     "valid JSON",
+			jsonData: `{"FIELD1":1,"FIELD2":0,"FIELD3":4,"FIELD4":5}`,
+			expected: SomeData{
+				Field1: NewValidInt(1),
+				Field2: NewValidInt(0),
+				Field3: NewValidInt(4),
+				Field4: NewValidInt(5),
+			},
+			expectErr: false,
+		},
+		{
+			name:     "JSON with missing fields",
+			jsonData: `{"FIELD1":1,"FIELD4":5}`,
+			expected: SomeData{
+				Field1: NewValidInt(1),
+				Field2: ValidInt{}, // Stays invalid (omitted)
+				Field3: ValidInt{}, // Stays invalid (omitted)
+				Field4: NewValidInt(5),
+			},
+			expectErr: false,
+		},
+		{
+			name:     "JSON with null fields",
+			jsonData: `{"FIELD1":null,"FIELD2":null,"FIELD3":null,"FIELD4":null}`,
+			expected: SomeData{
+				Field1: ValidInt{},
+				Field2: ValidInt{}, // Stays invalid (omitted)
+				Field3: ValidInt{}, // Stays invalid (omitted)
+				Field4: ValidInt{},
+			},
+			expectErr: false,
+		},
+		{
+			name:      "invalid JSON type for field (string instead of number)",
+			jsonData:  `{"FIELD1":"not-a-number","FIELD2":0}`,
+			expected:  SomeData{}, // Not checked on error
+			expectErr: true,
+		},
+		{
+			name:      "invalid JSON syntax",
+			jsonData:  `{"FIELD1":1,"FIELD2":0,}`, // trailing comma is invalid
+			expected:  SomeData{},                 // Not checked on error
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := SomeData{}
+			err := json.Unmarshal([]byte(tc.jsonData), &actual)
+
+			if tc.expectErr {
+				t.Logf("Reported Error: %s", err)
+				assert.Error(t, err, "Expected error when unmarshaling invalid JSON")
+			} else {
+				require.NoError(t, err, "Failed to unmarshal valid JSON")
+				assert.Equal(t, tc.expected, actual)
+			}
+		})
+	}
+}
+
+// TestValidIntString tests the String() method of ValidInt
+func TestValidInt_String(t *testing.T) {
+	resetInt := NewValidInt(100)
+	resetInt.Reset()
+
+	testCases := []struct {
+		name           string
+		input          ValidInt
+		expectedString string
+	}{
+		{
+			name:           "unset ValidInt returns empty string",
+			input:          ValidInt{}, // zero value
+			expectedString: "",
+		},
+		{
+			name:           "set to zero returns '0'",
+			input:          NewValidInt(0),
+			expectedString: "0",
+		},
+		{
+			name:           "positive value",
+			input:          NewValidInt(42),
+			expectedString: "42",
+		},
+		{
+			name:           "negative value",
+			input:          NewValidInt(-123),
+			expectedString: "-123",
+		},
+		{
+			name:           "reset returns empty string",
+			input:          resetInt,
+			expectedString: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.input.String()
+			assert.Equal(t, tc.expectedString, result, "String() returned unexpected value")
+		})
+	}
+}
+
+// TestNewValidInt tests the NewValidInt constructor
+func Test_NewValidInt(t *testing.T) {
+	testCases := []struct {
+		name          string
+		value         int
+		expectedValue int
+		expectedValid bool
+	}{
+		{
+			name:          "zero value",
+			value:         0,
+			expectedValue: 0,
+			expectedValid: true,
+		},
+		{
+			name:          "positive value",
+			value:         42,
+			expectedValue: 42,
+			expectedValid: true,
+		},
+		{
+			name:          "negative value",
+			value:         -100,
+			expectedValue: -100,
+			expectedValid: true,
+		},
+		{
+			name:          "max int",
+			value:         2147483647, // Assuming 32-bit int
+			expectedValue: 2147483647,
+			expectedValid: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			vi := NewValidInt(tc.value)
+
+			// Check Value field
+			assert.Equal(t, tc.expectedValue, vi.Value, "Value field mismatch")
+
+			// Check Valid field
+			assert.Equal(t, tc.expectedValid, vi.Valid, "Valid field mismatch")
+
+			// Verify using Get method as well
+			value, valid := vi.Get()
+			assert.Equal(t, tc.expectedValue, value, "Value from Get() mismatch")
+			assert.Equal(t, tc.expectedValid, valid, "Valid from Get() mismatch")
+
+			// IsZero should always be false for NewValidInt
+			assert.False(t, vi.IsZero(), "IsZero() should be false")
+		})
+	}
+}

--- a/pkg/validtypes/validtypes_test.go
+++ b/pkg/validtypes/validtypes_test.go
@@ -356,8 +356,8 @@ func TestUnmarshalJSON(t *testing.T) {
 				expectErr: false,
 			},
 			{
-				name:     "JSON with null fields",
-				jsonData: `{"FIELD1":null,"FIELD2":null,"FIELD3":null,"FIELD4":null}`,
+				name:     "JSON with null & NA fields",
+				jsonData: `{"FIELD1":null,"FIELD2":null,"FIELD3":"NA","FIELD4":"NA"}`,
 				expected: SomeData{
 					Field1: ValidInt{},
 					Field2: ValidInt{}, // Stays invalid (omitted)
@@ -433,8 +433,8 @@ func TestUnmarshalJSON(t *testing.T) {
 				expectErr: false,
 			},
 			{
-				name:     "JSON with null fields",
-				jsonData: `{"FIELD1":null,"FIELD2":null,"FIELD3":null,"FIELD4":null}`,
+				name:     "JSON with null & NA fields",
+				jsonData: `{"FIELD1":null,"FIELD2":null,"FIELD3":"NA","FIELD4":"NA"}`,
 				expected: SomeData{
 					Field1: ValidFloat{},
 					Field2: ValidFloat{},
@@ -510,8 +510,8 @@ func TestUnmarshalJSON(t *testing.T) {
 				expectErr: false,
 			},
 			{
-				name:     "JSON with null fields",
-				jsonData: `{"FIELD1":null,"FIELD2":null}`,
+				name:     "JSON with null & NA fields",
+				jsonData: `{"FIELD1":null,"FIELD2":"NA"}`,
 				expected: SomeData{
 					Field1: ValidString{},
 					Field2: ValidString{},

--- a/pkg/validtypes/validtypes_test.go
+++ b/pkg/validtypes/validtypes_test.go
@@ -599,7 +599,7 @@ func TestString(t *testing.T) {
 			expectedString string
 		}{
 			{
-				name:           "unset ValidInt returns empty string",
+				name:           "unset ValidFloat returns empty string",
 				input:          ValidFloat{}, // zero value
 				expectedString: "",
 			},
@@ -763,7 +763,7 @@ func TestNewValidType(t *testing.T) {
 				expectedValid: true,
 			},
 			{
-				name:          "max int",
+				name:          "fractional value",
 				value:         123.4567890,
 				expectedValue: 123.456789,
 				expectedValid: true,

--- a/pkg/validtypes/validtypes_test.go
+++ b/pkg/validtypes/validtypes_test.go
@@ -8,279 +8,292 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestValidIntIsZero confirms that IsZero behaves as expected.
-func TestValidInt_IsZero(t *testing.T) {
-	testCases := []struct {
-		name     string
-		action   func(vi *ValidInt)
-		expected bool
-	}{
-		{
-			name:     "Unset ValidInt should be zero",
-			action:   func(vi *ValidInt) {},
-			expected: true,
-		},
-		{
-			name:     "Set to 0 should NOT be zero",
-			action:   func(vi *ValidInt) { vi.Set(0) },
-			expected: false,
-		},
-		{
-			name:     "Set to non-zero should NOT be zero",
-			action:   func(vi *ValidInt) { vi.Set(42) },
-			expected: false,
-		},
-		{
-			name: "Reset should be zero",
-			action: func(vi *ValidInt) {
-				vi.Set(100) // Set to a value first
-				vi.Reset()
+// TestIsZero confirms that IsZero behaves as expected.
+func TestIsZero(t *testing.T) {
+	t.Parallel()
+	t.Run("ValidInt", func(t *testing.T) {
+		t.Parallel()
+		testCases := []struct {
+			name     string
+			action   func(vi *ValidInt)
+			expected bool
+		}{
+			{
+				name:     "Unset ValidInt should be zero value",
+				action:   func(vi *ValidInt) {},
+				expected: true,
 			},
-			expected: true,
-		},
-	}
+			{
+				name:     "Set to 0 should NOT be zero value",
+				action:   func(vi *ValidInt) { vi.Set(0) },
+				expected: false,
+			},
+			{
+				name:     "Set to non-zero should NOT be zero value",
+				action:   func(vi *ValidInt) { vi.Set(42) },
+				expected: false,
+			},
+			{
+				name: "Reset should be zero value",
+				action: func(vi *ValidInt) {
+					vi.Set(100) // Set to a value first
+					vi.Reset()
+				},
+				expected: true,
+			},
+		}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			var vi ValidInt
-			tc.action(&vi)
-			assert.Equal(t, tc.expected, vi.IsZero())
-		})
-	}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				var vi ValidInt
+				tc.action(&vi)
+				assert.Equal(t, tc.expected, vi.IsZero())
+			})
+		}
+	})
 }
 
-// TestValidIntMarshal tests marshaling ValidInt with different JSON tags
-func TestValidInt_MarshalJSON(t *testing.T) {
-	type OmitzeroData struct {
-		Field1 ValidInt `json:"FIELD1,omitzero"`
-		Field2 ValidInt `json:"FIELD2,omitzero"`
-		Field3 ValidInt `json:"FIELD3,omitzero"`
-		Field4 ValidInt `json:"FIELD4,omitzero"`
-	}
-	type OmitemptyData struct {
-		Field1 ValidInt `json:"FIELD1,omitempty"`
-		Field2 ValidInt `json:"FIELD2,omitempty"`
-		Field3 ValidInt `json:"FIELD3,omitempty"`
-		Field4 ValidInt `json:"FIELD4,omitempty"`
-	}
-	testCases := []struct {
-		name         string
-		setupData    func() interface{}
-		expectedJSON string
-	}{
-		{
-			name: "omitzero tag",
-			setupData: func() interface{} {
-				sd := OmitzeroData{}
-				sd.Field1.Set(1)
-				sd.Field2.Set(0)
-				sd.Field4.Set(5)
-				// Field3 remains unset
-				return sd
+// TestMarshalJSON tests marshaling our validtypes with different JSON tags
+func TestMarshalJSON(t *testing.T) {
+	t.Run("ValidInt", func(t *testing.T) {
+		type OmitzeroData struct {
+			Field1 ValidInt `json:"FIELD1,omitzero"`
+			Field2 ValidInt `json:"FIELD2,omitzero"`
+			Field3 ValidInt `json:"FIELD3,omitzero"`
+			Field4 ValidInt `json:"FIELD4,omitzero"`
+		}
+		type OmitemptyData struct {
+			Field1 ValidInt `json:"FIELD1,omitempty"`
+			Field2 ValidInt `json:"FIELD2,omitempty"`
+			Field3 ValidInt `json:"FIELD3,omitempty"`
+			Field4 ValidInt `json:"FIELD4,omitempty"`
+		}
+		testCases := []struct {
+			name         string
+			setupData    func() interface{}
+			expectedJSON string
+		}{
+			{
+				name: "omitzero tag",
+				setupData: func() interface{} {
+					sd := OmitzeroData{}
+					sd.Field1.Set(1)
+					sd.Field2.Set(0)
+					sd.Field4.Set(5)
+					// Field3 remains unset
+					return sd
+				},
+				expectedJSON: `{"FIELD1":1,"FIELD2":0,"FIELD4":5}`,
 			},
-			expectedJSON: `{"FIELD1":1,"FIELD2":0,"FIELD4":5}`,
-		},
-		{
-			name: "omitempty tag",
-			setupData: func() interface{} {
-				sd := OmitemptyData{}
-				sd.Field1.Set(1)
-				sd.Field2.Set(0)
-				sd.Field4.Set(5)
-				// Field3 remains unset
-				return sd
+			{
+				name: "omitempty tag",
+				setupData: func() interface{} {
+					sd := OmitemptyData{}
+					sd.Field1.Set(1)
+					sd.Field2.Set(0)
+					sd.Field4.Set(5)
+					// Field3 remains unset
+					return sd
+				},
+				expectedJSON: `{"FIELD1":1,"FIELD2":0,"FIELD3":null,"FIELD4":5}`,
 			},
-			expectedJSON: `{"FIELD1":1,"FIELD2":0,"FIELD3":null,"FIELD4":5}`,
-		},
-	}
+		}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			data := tc.setupData()
-			jsonData, err := json.Marshal(data)
-			require.NoError(t, err, "Failed to marshal JSON")
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				data := tc.setupData()
+				jsonData, err := json.Marshal(data)
+				require.NoError(t, err, "Failed to marshal JSON")
 
-			jsonStr := string(jsonData)
-			t.Logf("Generated JSON: %s", jsonStr)
-			assert.JSONEq(t, tc.expectedJSON, jsonStr)
-		})
-	}
+				jsonStr := string(jsonData)
+				t.Logf("Generated JSON: %s", jsonStr)
+				assert.JSONEq(t, tc.expectedJSON, jsonStr)
+			})
+		}
+	})
 }
 
-// TestValidIntUnmarshal tests unmarshaling JSON into ValidInt fields
-func TestValidInt_UnmarshalJSON(t *testing.T) {
-	type SomeData struct {
-		Field1 ValidInt `json:"FIELD1"`
-		Field2 ValidInt `json:"FIELD2"`
-		Field3 ValidInt `json:"FIELD3"`
-		Field4 ValidInt `json:"FIELD4"`
-	}
+// TestUnmarshalJSON tests unmarshaling JSON into appropriate validtype fields
+func TestUnmarshalJSON(t *testing.T) {
+	t.Run("ValidInt", func(t *testing.T) {
+		type SomeData struct {
+			Field1 ValidInt `json:"FIELD1"`
+			Field2 ValidInt `json:"FIELD2"`
+			Field3 ValidInt `json:"FIELD3"`
+			Field4 ValidInt `json:"FIELD4"`
+		}
 
-	testCases := []struct {
-		name      string
-		jsonData  string
-		expected  SomeData
-		expectErr bool
-	}{
-		{
-			name:     "valid JSON",
-			jsonData: `{"FIELD1":1,"FIELD2":0,"FIELD3":4,"FIELD4":5}`,
-			expected: SomeData{
-				Field1: NewValidInt(1),
-				Field2: NewValidInt(0),
-				Field3: NewValidInt(4),
-				Field4: NewValidInt(5),
+		testCases := []struct {
+			name      string
+			jsonData  string
+			expected  SomeData
+			expectErr bool
+		}{
+			{
+				name:     "valid JSON",
+				jsonData: `{"FIELD1":1,"FIELD2":0,"FIELD3":4,"FIELD4":5}`,
+				expected: SomeData{
+					Field1: NewValidInt(1),
+					Field2: NewValidInt(0),
+					Field3: NewValidInt(4),
+					Field4: NewValidInt(5),
+				},
+				expectErr: false,
 			},
-			expectErr: false,
-		},
-		{
-			name:     "JSON with missing fields",
-			jsonData: `{"FIELD1":1,"FIELD4":5}`,
-			expected: SomeData{
-				Field1: NewValidInt(1),
-				Field2: ValidInt{}, // Stays invalid (omitted)
-				Field3: ValidInt{}, // Stays invalid (omitted)
-				Field4: NewValidInt(5),
+			{
+				name:     "JSON with missing fields",
+				jsonData: `{"FIELD1":1,"FIELD4":5}`,
+				expected: SomeData{
+					Field1: NewValidInt(1),
+					Field2: ValidInt{}, // Stays invalid (omitted)
+					Field3: ValidInt{}, // Stays invalid (omitted)
+					Field4: NewValidInt(5),
+				},
+				expectErr: false,
 			},
-			expectErr: false,
-		},
-		{
-			name:     "JSON with null fields",
-			jsonData: `{"FIELD1":null,"FIELD2":null,"FIELD3":null,"FIELD4":null}`,
-			expected: SomeData{
-				Field1: ValidInt{},
-				Field2: ValidInt{}, // Stays invalid (omitted)
-				Field3: ValidInt{}, // Stays invalid (omitted)
-				Field4: ValidInt{},
+			{
+				name:     "JSON with null fields",
+				jsonData: `{"FIELD1":null,"FIELD2":null,"FIELD3":null,"FIELD4":null}`,
+				expected: SomeData{
+					Field1: ValidInt{},
+					Field2: ValidInt{}, // Stays invalid (omitted)
+					Field3: ValidInt{}, // Stays invalid (omitted)
+					Field4: ValidInt{},
+				},
+				expectErr: false,
 			},
-			expectErr: false,
-		},
-		{
-			name:      "invalid JSON type for field (string instead of number)",
-			jsonData:  `{"FIELD1":"not-a-number","FIELD2":0}`,
-			expected:  SomeData{}, // Not checked on error
-			expectErr: true,
-		},
-		{
-			name:      "invalid JSON syntax",
-			jsonData:  `{"FIELD1":1,"FIELD2":0,}`, // trailing comma is invalid
-			expected:  SomeData{},                 // Not checked on error
-			expectErr: true,
-		},
-	}
+			{
+				name:      "invalid JSON type for field (string instead of number)",
+				jsonData:  `{"FIELD1":"not-a-number","FIELD2":0}`,
+				expected:  SomeData{}, // Not checked on error
+				expectErr: true,
+			},
+			{
+				name:      "invalid JSON syntax",
+				jsonData:  `{"FIELD1":1,"FIELD2":0,}`, // trailing comma is invalid
+				expected:  SomeData{},                 // Not checked on error
+				expectErr: true,
+			},
+		}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := SomeData{}
-			err := json.Unmarshal([]byte(tc.jsonData), &actual)
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				actual := SomeData{}
+				err := json.Unmarshal([]byte(tc.jsonData), &actual)
 
-			if tc.expectErr {
-				t.Logf("Reported Error: %s", err)
-				assert.Error(t, err, "Expected error when unmarshaling invalid JSON")
-			} else {
-				require.NoError(t, err, "Failed to unmarshal valid JSON")
-				assert.Equal(t, tc.expected, actual)
-			}
-		})
-	}
+				if tc.expectErr {
+					t.Logf("Reported Error: %s", err)
+					assert.Error(t, err, "Expected error when unmarshaling invalid JSON")
+				} else {
+					require.NoError(t, err, "Failed to unmarshal valid JSON")
+					assert.Equal(t, tc.expected, actual)
+				}
+			})
+		}
+	})
 }
 
-// TestValidIntString tests the String() method of ValidInt
-func TestValidInt_String(t *testing.T) {
-	resetInt := NewValidInt(100)
-	resetInt.Reset()
+// TestString tests the String() method of the validtypes
+func TestString(t *testing.T) {
+	t.Run("ValidInt", func(t *testing.T) {
+		resetInt := NewValidInt(100)
+		resetInt.Reset()
 
-	testCases := []struct {
-		name           string
-		input          ValidInt
-		expectedString string
-	}{
-		{
-			name:           "unset ValidInt returns empty string",
-			input:          ValidInt{}, // zero value
-			expectedString: "",
-		},
-		{
-			name:           "set to zero returns '0'",
-			input:          NewValidInt(0),
-			expectedString: "0",
-		},
-		{
-			name:           "positive value",
-			input:          NewValidInt(42),
-			expectedString: "42",
-		},
-		{
-			name:           "negative value",
-			input:          NewValidInt(-123),
-			expectedString: "-123",
-		},
-		{
-			name:           "reset returns empty string",
-			input:          resetInt,
-			expectedString: "",
-		},
-	}
+		testCases := []struct {
+			name           string
+			input          ValidInt
+			expectedString string
+		}{
+			{
+				name:           "unset ValidInt returns empty string",
+				input:          ValidInt{}, // zero value
+				expectedString: "",
+			},
+			{
+				name:           "set to zero returns '0'",
+				input:          NewValidInt(0),
+				expectedString: "0",
+			},
+			{
+				name:           "positive value",
+				input:          NewValidInt(42),
+				expectedString: "42",
+			},
+			{
+				name:           "negative value",
+				input:          NewValidInt(-123),
+				expectedString: "-123",
+			},
+			{
+				name:           "reset returns empty string",
+				input:          resetInt,
+				expectedString: "",
+			},
+		}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result := tc.input.String()
-			assert.Equal(t, tc.expectedString, result, "String() returned unexpected value")
-		})
-	}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				result := tc.input.String()
+				assert.Equal(t, tc.expectedString, result, "String() returned unexpected value")
+			})
+		}
+	})
 }
 
-// TestNewValidInt tests the NewValidInt constructor
-func Test_NewValidInt(t *testing.T) {
-	testCases := []struct {
-		name          string
-		value         int
-		expectedValue int
-		expectedValid bool
-	}{
-		{
-			name:          "zero value",
-			value:         0,
-			expectedValue: 0,
-			expectedValid: true,
-		},
-		{
-			name:          "positive value",
-			value:         42,
-			expectedValue: 42,
-			expectedValid: true,
-		},
-		{
-			name:          "negative value",
-			value:         -100,
-			expectedValue: -100,
-			expectedValid: true,
-		},
-		{
-			name:          "max int",
-			value:         2147483647, // Assuming 32-bit int
-			expectedValue: 2147483647,
-			expectedValid: true,
-		},
-	}
+// TestNewValidType tests the NewValid* constructors
+func TestNewValidType(t *testing.T) {
+	t.Run("ValidInt", func(t *testing.T) {
+		testCases := []struct {
+			name          string
+			value         int
+			expectedValue int
+			expectedValid bool
+		}{
+			{
+				name:          "zero value",
+				value:         0,
+				expectedValue: 0,
+				expectedValid: true,
+			},
+			{
+				name:          "positive value",
+				value:         42,
+				expectedValue: 42,
+				expectedValid: true,
+			},
+			{
+				name:          "negative value",
+				value:         -100,
+				expectedValue: -100,
+				expectedValid: true,
+			},
+			{
+				name:          "max int",
+				value:         2147483647, // Assuming 32-bit int
+				expectedValue: 2147483647,
+				expectedValid: true,
+			},
+		}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			vi := NewValidInt(tc.value)
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				vi := NewValidInt(tc.value)
 
-			// Check Value field
-			assert.Equal(t, tc.expectedValue, vi.Value, "Value field mismatch")
+				// Check Value field
+				assert.Equal(t, tc.expectedValue, vi.Value, "Value field mismatch")
 
-			// Check Valid field
-			assert.Equal(t, tc.expectedValid, vi.Valid, "Valid field mismatch")
+				// Check Valid field
+				assert.Equal(t, tc.expectedValid, vi.Valid, "Valid field mismatch")
 
-			// Verify using Get method as well
-			value, valid := vi.Get()
-			assert.Equal(t, tc.expectedValue, value, "Value from Get() mismatch")
-			assert.Equal(t, tc.expectedValid, valid, "Valid from Get() mismatch")
+				// Verify using Get method as well
+				value, valid := vi.Get()
+				assert.Equal(t, tc.expectedValue, value, "Value from Get() mismatch")
+				assert.Equal(t, tc.expectedValid, valid, "Valid from Get() mismatch")
 
-			// IsZero should always be false for NewValidInt
-			assert.False(t, vi.IsZero(), "IsZero() should be false")
-		})
-	}
+				// IsZero should always be false for NewValidInt
+				assert.False(t, vi.IsZero(), "IsZero() should be false")
+			})
+		}
+	})
 }

--- a/pkg/validtypes/validtypes_test.go
+++ b/pkg/validtypes/validtypes_test.go
@@ -94,6 +94,53 @@ func TestIsZero(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("ValidString", func(t *testing.T) {
+		t.Parallel()
+		testCases := []struct {
+			name     string
+			action   func(vs *ValidString)
+			expected bool
+		}{
+			{
+				name:     "Unset should be zero value",
+				action:   func(vs *ValidString) {},
+				expected: true,
+			},
+			{
+				name:     "Set to empty string should NOT be zero value",
+				action:   func(vs *ValidString) { vs.Set("") },
+				expected: false,
+			},
+			{
+				name:     "Set to NA should be zero value",
+				action:   func(vs *ValidString) { vs.Set("NA") },
+				expected: true,
+			},
+			{
+				name:     "Set to non-empty string should NOT be zero value",
+				action:   func(vs *ValidString) { vs.Set("hello") },
+				expected: false,
+			},
+			{
+				name: "Reset should be zero value",
+				action: func(vs *ValidString) {
+					vs.Set("world")
+					vs.Reset()
+				},
+				expected: true,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				var vs ValidString
+				tc.action(&vs)
+				assert.Equal(t, tc.expected, vs.IsZero())
+			})
+		}
+	})
 }
 
 // TestMarshalJSON tests marshaling our validtypes with different JSON tags
@@ -196,6 +243,63 @@ func TestMarshalJSON(t *testing.T) {
 					return sd
 				},
 				expectedJSON: `{"FIELD1":1,"FIELD2":0,"FIELD3":null,"FIELD4":5.2}`,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				data := tc.setupData()
+				jsonData, err := json.Marshal(data)
+				require.NoError(t, err, "Failed to marshal JSON")
+
+				jsonStr := string(jsonData)
+				t.Logf("Generated JSON: %s", jsonStr)
+				assert.JSONEq(t, tc.expectedJSON, jsonStr)
+			})
+		}
+	})
+
+	t.Run("ValidString", func(t *testing.T) {
+		type OmitzeroData struct {
+			Field1 ValidString `json:"FIELD1,omitzero"`
+			Field2 ValidString `json:"FIELD2,omitzero"`
+			Field3 ValidString `json:"FIELD3,omitzero"`
+			Field4 ValidString `json:"FIELD4,omitzero"`
+		}
+		type OmitemptyData struct {
+			Field1 ValidString `json:"FIELD1,omitempty"`
+			Field2 ValidString `json:"FIELD2,omitempty"`
+			Field3 ValidString `json:"FIELD3,omitempty"`
+			Field4 ValidString `json:"FIELD4,omitempty"`
+		}
+		testCases := []struct {
+			name         string
+			setupData    func() interface{}
+			expectedJSON string
+		}{
+			{
+				name: "omitzero tag",
+				setupData: func() interface{} {
+					sd := OmitzeroData{}
+					sd.Field1.Set("hello")
+					sd.Field2.Set("")   // empty string is valid
+					sd.Field4.Set("NA") // this will be unset
+					// Field3 remains unset
+					return sd
+				},
+				expectedJSON: `{"FIELD1":"hello","FIELD2":""}`,
+			},
+			{
+				name: "omitempty tag",
+				setupData: func() interface{} {
+					sd := OmitemptyData{}
+					sd.Field1.Set("hello")
+					sd.Field2.Set("")
+					sd.Field4.Set("NA")
+					// Field3 remains unset
+					return sd
+				},
+				expectedJSON: `{"FIELD1":"hello","FIELD2":"","FIELD3":null,"FIELD4":null}`,
 			},
 		}
 
@@ -368,6 +472,75 @@ func TestUnmarshalJSON(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("ValidString", func(t *testing.T) {
+		type SomeData struct {
+			Field1 ValidString `json:"FIELD1"`
+			Field2 ValidString `json:"FIELD2"`
+			Field3 ValidString `json:"FIELD3"`
+			Field4 ValidString `json:"FIELD4"`
+		}
+
+		testCases := []struct {
+			name      string
+			jsonData  string
+			expected  SomeData
+			expectErr bool
+		}{
+			{
+				name:     "valid JSON with strings",
+				jsonData: `{"FIELD1":"hello","FIELD2":"","FIELD3":"world","FIELD4":"NA"}`,
+				expected: SomeData{
+					Field1: NewValidString("hello"),
+					Field2: NewValidString(""),
+					Field3: NewValidString("world"),
+					Field4: ValidString{}, // NA becomes invalid
+				},
+				expectErr: false,
+			},
+			{
+				name:     "JSON with missing fields",
+				jsonData: `{"FIELD1":"hello"}`,
+				expected: SomeData{
+					Field1: NewValidString("hello"),
+					Field2: ValidString{},
+					Field3: ValidString{},
+					Field4: ValidString{},
+				},
+				expectErr: false,
+			},
+			{
+				name:     "JSON with null fields",
+				jsonData: `{"FIELD1":null,"FIELD2":null}`,
+				expected: SomeData{
+					Field1: ValidString{},
+					Field2: ValidString{},
+				},
+				expectErr: false,
+			},
+			{
+				name:      "invalid JSON type for field (number instead of string)",
+				jsonData:  `{"FIELD1":123}`,
+				expected:  SomeData{},
+				expectErr: true,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				actual := SomeData{}
+				err := json.Unmarshal([]byte(tc.jsonData), &actual)
+
+				if tc.expectErr {
+					t.Logf("Reported Error: %s", err)
+					assert.Error(t, err, "Expected error when unmarshaling invalid JSON")
+				} else {
+					require.NoError(t, err, "Failed to unmarshal valid JSON")
+					assert.Equal(t, tc.expected, actual)
+				}
+			})
+		}
+	})
 }
 
 // TestString tests the String() method of the validtypes
@@ -453,6 +626,50 @@ func TestString(t *testing.T) {
 			{
 				name:           "reset returns empty string",
 				input:          resetFloat,
+				expectedString: "",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				result := tc.input.String()
+				assert.Equal(t, tc.expectedString, result, "String() returned unexpected value")
+			})
+		}
+	})
+
+	t.Run("ValidString", func(t *testing.T) {
+		resetString := NewValidString("something")
+		resetString.Reset()
+
+		testCases := []struct {
+			name           string
+			input          ValidString
+			expectedString string
+		}{
+			{
+				name:           "unset returns empty string",
+				input:          ValidString{},
+				expectedString: "",
+			},
+			{
+				name:           "set to empty string returns empty string",
+				input:          NewValidString(""),
+				expectedString: "",
+			},
+			{
+				name:           "set to NA returns empty string",
+				input:          NewValidString("NA"),
+				expectedString: "",
+			},
+			{
+				name:           "set to a value returns the value",
+				input:          NewValidString("hello"),
+				expectedString: "hello",
+			},
+			{
+				name:           "reset returns empty string",
+				input:          resetString,
 				expectedString: "",
 			},
 		}
@@ -569,6 +786,49 @@ func TestNewValidType(t *testing.T) {
 
 				// IsZero should always be false for NewValidFloat
 				assert.False(t, vi.IsZero(), "IsZero() should be false")
+			})
+		}
+	})
+
+	t.Run("ValidString", func(t *testing.T) {
+		testCases := []struct {
+			name          string
+			value         string
+			expectedValue string
+			expectedValid bool
+		}{
+			{
+				name:          "non-empty string",
+				value:         "hello",
+				expectedValue: "hello",
+				expectedValid: true,
+			},
+			{
+				name:          "empty string",
+				value:         "",
+				expectedValue: "",
+				expectedValid: true,
+			},
+			{
+				name:          "NA string",
+				value:         "NA",
+				expectedValue: "", // Value should be empty for invalid
+				expectedValid: false,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				vs := NewValidString(tc.value)
+
+				assert.Equal(t, tc.expectedValue, vs.Value, "Value field mismatch")
+				assert.Equal(t, tc.expectedValid, vs.Valid, "Valid field mismatch")
+
+				value, valid := vs.Get()
+				assert.Equal(t, tc.expectedValue, value, "Value from Get() mismatch")
+				assert.Equal(t, tc.expectedValid, valid, "Valid from Get() mismatch")
+
+				assert.Equal(t, !tc.expectedValid, vs.IsZero(), "IsZero() mismatch")
 			})
 		}
 	})

--- a/pkg/validtypes/validtypes_test.go
+++ b/pkg/validtypes/validtypes_test.go
@@ -52,6 +52,48 @@ func TestIsZero(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("ValidFloat", func(t *testing.T) {
+		t.Parallel()
+		testCases := []struct {
+			name     string
+			action   func(vf *ValidFloat)
+			expected bool
+		}{
+			{
+				name:     "Unset should be zero value",
+				action:   func(vf *ValidFloat) {},
+				expected: true,
+			},
+			{
+				name:     "Set to 0.0 should NOT be zero value",
+				action:   func(vf *ValidFloat) { vf.Set(0.0) },
+				expected: false,
+			},
+			{
+				name:     "Set to non-zero should NOT be zero value",
+				action:   func(vf *ValidFloat) { vf.Set(42.5) },
+				expected: false,
+			},
+			{
+				name: "Reset should be zero value",
+				action: func(vf *ValidFloat) {
+					vf.Set(100.5)
+					vf.Reset()
+				},
+				expected: true,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				var vf ValidFloat
+				tc.action(&vf)
+				assert.Equal(t, tc.expected, vf.IsZero())
+			})
+		}
+	})
 }
 
 // TestMarshalJSON tests marshaling our validtypes with different JSON tags
@@ -97,6 +139,63 @@ func TestMarshalJSON(t *testing.T) {
 					return sd
 				},
 				expectedJSON: `{"FIELD1":1,"FIELD2":0,"FIELD3":null,"FIELD4":5}`,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				data := tc.setupData()
+				jsonData, err := json.Marshal(data)
+				require.NoError(t, err, "Failed to marshal JSON")
+
+				jsonStr := string(jsonData)
+				t.Logf("Generated JSON: %s", jsonStr)
+				assert.JSONEq(t, tc.expectedJSON, jsonStr)
+			})
+		}
+	})
+
+	t.Run("ValidFloat", func(t *testing.T) {
+		type OmitzeroData struct {
+			Field1 ValidFloat `json:"FIELD1,omitzero"`
+			Field2 ValidFloat `json:"FIELD2,omitzero"`
+			Field3 ValidFloat `json:"FIELD3,omitzero"`
+			Field4 ValidFloat `json:"FIELD4,omitzero"`
+		}
+		type OmitemptyData struct {
+			Field1 ValidFloat `json:"FIELD1,omitempty"`
+			Field2 ValidFloat `json:"FIELD2,omitempty"`
+			Field3 ValidFloat `json:"FIELD3,omitempty"`
+			Field4 ValidFloat `json:"FIELD4,omitempty"`
+		}
+		testCases := []struct {
+			name         string
+			setupData    func() interface{}
+			expectedJSON string
+		}{
+			{
+				name: "omitzero tag",
+				setupData: func() interface{} {
+					sd := OmitzeroData{}
+					sd.Field1.Set(1)
+					sd.Field2.Set(0)
+					sd.Field4.Set(5.2)
+					// Field3 remains unset
+					return sd
+				},
+				expectedJSON: `{"FIELD1":1,"FIELD2":0,"FIELD4":5.2}`,
+			},
+			{
+				name: "omitempty tag",
+				setupData: func() interface{} {
+					sd := OmitemptyData{}
+					sd.Field1.Set(1)
+					sd.Field2.Set(0)
+					sd.Field4.Set(5.2)
+					// Field3 remains unset
+					return sd
+				},
+				expectedJSON: `{"FIELD1":1,"FIELD2":0,"FIELD3":null,"FIELD4":5.2}`,
 			},
 		}
 
@@ -192,6 +291,83 @@ func TestUnmarshalJSON(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("ValidFloat", func(t *testing.T) {
+		type SomeData struct {
+			Field1 ValidFloat `json:"FIELD1"`
+			Field2 ValidFloat `json:"FIELD2"`
+			Field3 ValidFloat `json:"FIELD3"`
+			Field4 ValidFloat `json:"FIELD4"`
+		}
+
+		testCases := []struct {
+			name      string
+			jsonData  string
+			expected  SomeData
+			expectErr bool
+		}{
+			{
+				name:     "valid JSON",
+				jsonData: `{"FIELD1":1,"FIELD2":0,"FIELD3":4,"FIELD4":5.2}`,
+				expected: SomeData{
+					Field1: NewValidFloat(1),
+					Field2: NewValidFloat(0),
+					Field3: NewValidFloat(4),
+					Field4: NewValidFloat(5.2),
+				},
+				expectErr: false,
+			},
+			{
+				name:     "JSON with missing fields",
+				jsonData: `{"FIELD1":1,"FIELD4":5.2}`,
+				expected: SomeData{
+					Field1: NewValidFloat(1),
+					Field2: ValidFloat{}, // Stays invalid (omitted)
+					Field3: ValidFloat{}, // Stays invalid (omitted)
+					Field4: NewValidFloat(5.2),
+				},
+				expectErr: false,
+			},
+			{
+				name:     "JSON with null fields",
+				jsonData: `{"FIELD1":null,"FIELD2":null,"FIELD3":null,"FIELD4":null}`,
+				expected: SomeData{
+					Field1: ValidFloat{},
+					Field2: ValidFloat{},
+					Field3: ValidFloat{},
+					Field4: ValidFloat{},
+				},
+				expectErr: false,
+			},
+			{
+				name:      "invalid JSON type for field (string instead of number)",
+				jsonData:  `{"FIELD1":"not-a-number","FIELD2":0}`,
+				expected:  SomeData{}, // Not checked on error
+				expectErr: true,
+			},
+			{
+				name:      "invalid JSON syntax",
+				jsonData:  `{"FIELD1":1,"FIELD2":0,}`, // trailing comma is invalid
+				expected:  SomeData{},                 // Not checked on error
+				expectErr: true,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				actual := SomeData{}
+				err := json.Unmarshal([]byte(tc.jsonData), &actual)
+
+				if tc.expectErr {
+					t.Logf("Reported Error: %s", err)
+					assert.Error(t, err, "Expected error when unmarshaling invalid JSON")
+				} else {
+					require.NoError(t, err, "Failed to unmarshal valid JSON")
+					assert.Equal(t, tc.expected, actual)
+				}
+			})
+		}
+	})
 }
 
 // TestString tests the String() method of the validtypes
@@ -228,6 +404,55 @@ func TestString(t *testing.T) {
 			{
 				name:           "reset returns empty string",
 				input:          resetInt,
+				expectedString: "",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				result := tc.input.String()
+				assert.Equal(t, tc.expectedString, result, "String() returned unexpected value")
+			})
+		}
+	})
+
+	t.Run("ValidFloat", func(t *testing.T) {
+		resetFloat := NewValidFloat(100.2)
+		resetFloat.Reset()
+
+		testCases := []struct {
+			name           string
+			input          ValidFloat
+			expectedString string
+		}{
+			{
+				name:           "unset ValidInt returns empty string",
+				input:          ValidFloat{}, // zero value
+				expectedString: "",
+			},
+			{
+				name:           "set to zero returns '0'",
+				input:          NewValidFloat(0),
+				expectedString: "0",
+			},
+			{
+				name:           "positive value",
+				input:          NewValidFloat(42),
+				expectedString: "42",
+			},
+			{
+				name:           "negative value",
+				input:          NewValidFloat(-123),
+				expectedString: "-123",
+			},
+			{
+				name:           "Fractional value",
+				input:          NewValidFloat(123.456789),
+				expectedString: "123.456789",
+			},
+			{
+				name:           "reset returns empty string",
+				input:          resetFloat,
 				expectedString: "",
 			},
 		}
@@ -280,10 +505,8 @@ func TestNewValidType(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				vi := NewValidInt(tc.value)
 
-				// Check Value field
+				// Check struct fields
 				assert.Equal(t, tc.expectedValue, vi.Value, "Value field mismatch")
-
-				// Check Valid field
 				assert.Equal(t, tc.expectedValid, vi.Valid, "Valid field mismatch")
 
 				// Verify using Get method as well
@@ -292,6 +515,59 @@ func TestNewValidType(t *testing.T) {
 				assert.Equal(t, tc.expectedValid, valid, "Valid from Get() mismatch")
 
 				// IsZero should always be false for NewValidInt
+				assert.False(t, vi.IsZero(), "IsZero() should be false")
+			})
+		}
+	})
+
+	t.Run("ValidFloat", func(t *testing.T) {
+		testCases := []struct {
+			name          string
+			value         float64
+			expectedValue float64
+			expectedValid bool
+		}{
+			{
+				name:          "zero value",
+				value:         0,
+				expectedValue: 0,
+				expectedValid: true,
+			},
+			{
+				name:          "positive value",
+				value:         42,
+				expectedValue: 42,
+				expectedValid: true,
+			},
+			{
+				name:          "negative value",
+				value:         -100,
+				expectedValue: -100,
+				expectedValid: true,
+			},
+			{
+				name:          "max int",
+				value:         123.4567890,
+				expectedValue: 123.456789,
+				expectedValid: true,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				vi := NewValidFloat(tc.value)
+				delta := 0.0000001
+
+				// Check struct fields
+				assert.InDelta(t, tc.expectedValue, vi.Value, delta, "Value field mismatch")
+				assert.Equal(t, tc.expectedValid, vi.Valid, "Valid field mismatch")
+
+				// Verify using Get method as well
+				value, valid := vi.Get()
+				assert.InDelta(t, tc.expectedValue, value, delta, "Value from Get() mismatch")
+				assert.Equal(t, tc.expectedValid, valid, "Valid from Get() mismatch")
+
+				// IsZero should always be false for NewValidFloat
 				assert.False(t, vi.IsZero(), "IsZero() should be false")
 			})
 		}

--- a/pkg/validtypes/validtypes_test.go
+++ b/pkg/validtypes/validtypes_test.go
@@ -543,6 +543,104 @@ func TestUnmarshalJSON(t *testing.T) {
 	})
 }
 
+// TestUnmarshalText tests the UnmarshalText method for each valid type.
+func TestUnmarshalText(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ValidInt", func(t *testing.T) {
+		t.Parallel()
+		testCases := []struct {
+			name      string
+			input     []byte
+			expected  ValidInt
+			expectErr bool
+		}{
+			{"valid number", []byte("123"), NewValidInt(123), false},
+			{"zero", []byte("0"), NewValidInt(0), false},
+			{"negative number", []byte("-45"), NewValidInt(-45), false},
+			{"NA value", []byte("NA"), ValidInt{}, false},
+			{"empty string", []byte(""), ValidInt{}, false},
+			{"invalid number", []byte("abc"), ValidInt{}, true},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				var vi ValidInt
+				err := vi.UnmarshalText(tc.input)
+
+				if tc.expectErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+				assert.Equal(t, tc.expected, vi)
+			})
+		}
+	})
+
+	t.Run("ValidFloat", func(t *testing.T) {
+		t.Parallel()
+		testCases := []struct {
+			name      string
+			input     []byte
+			expected  ValidFloat
+			expectErr bool
+		}{
+			{"valid float", []byte("123.45"), NewValidFloat(123.45), false},
+			{"zero", []byte("0.0"), NewValidFloat(0.0), false},
+			{"negative float", []byte("-45.6"), NewValidFloat(-45.6), false},
+			{"NA value", []byte("NA"), ValidFloat{}, false},
+			{"empty string", []byte(""), ValidFloat{}, false},
+			{"invalid float", []byte("abc"), ValidFloat{}, true},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				var vf ValidFloat
+				err := vf.UnmarshalText(tc.input)
+
+				if tc.expectErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+				assert.Equal(t, tc.expected, vf)
+			})
+		}
+	})
+
+	t.Run("ValidString", func(t *testing.T) {
+		t.Parallel()
+		testCases := []struct {
+			name      string
+			input     []byte
+			expected  ValidString
+			expectErr bool
+		}{
+			{"valid string", []byte("hello"), NewValidString("hello"), false},
+			{"NA value", []byte("NA"), ValidString{}, false},
+			{"empty string", []byte(""), ValidString{}, false},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				var vs ValidString
+				err := vs.UnmarshalText(tc.input)
+
+				if tc.expectErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+				assert.Equal(t, tc.expected, vs)
+			})
+		}
+	})
+}
+
 // TestString tests the String() method of the validtypes
 func TestString(t *testing.T) {
 	t.Run("ValidInt", func(t *testing.T) {

--- a/pkg/validtypes/validtypes_test.go
+++ b/pkg/validtypes/validtypes_test.go
@@ -1,4 +1,4 @@
-package trial
+package validtypes
 
 import (
 	"encoding/json"

--- a/pkg/validtypes/validtypes_test.go
+++ b/pkg/validtypes/validtypes_test.go
@@ -570,9 +570,9 @@ func TestUnmarshalText(t *testing.T) {
 				err := vi.UnmarshalText(tc.input)
 
 				if tc.expectErr {
-					assert.Error(t, err)
+					require.Error(t, err)
 				} else {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				}
 				assert.Equal(t, tc.expected, vi)
 			})
@@ -602,9 +602,9 @@ func TestUnmarshalText(t *testing.T) {
 				err := vf.UnmarshalText(tc.input)
 
 				if tc.expectErr {
-					assert.Error(t, err)
+					require.Error(t, err)
 				} else {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				}
 				assert.Equal(t, tc.expected, vf)
 			})
@@ -631,9 +631,9 @@ func TestUnmarshalText(t *testing.T) {
 				err := vs.UnmarshalText(tc.input)
 
 				if tc.expectErr {
-					assert.Error(t, err)
+					require.Error(t, err)
 				} else {
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				}
 				assert.Equal(t, tc.expected, vs)
 			})


### PR DESCRIPTION
Add a `validtypes` package that implements wrapper types (`ValidInt`, `ValidFloat`, `ValidString`) to distinguish between intentionally set zero values and unset fields. Being able to differentiate between a value that has been deliberately set to zero and a type that has been unset and is at its "zero value" is important for us. Zero values will influence some of the statistics calculated from the MET stat data.

To support this, we switch from Go's `omitempty` tag to [Go 1.24's `omitzero` JSON tag](https://tip.golang.org/doc/go1.24#encodingjsonpkgencodingjson) as `omitzero` behavior can be controlled by implementing `.IsZero()` methods. The implementation includes comprehensive JSON marshaling/unmarshaling, text marshaling, and proper handling of "NA" values as invalid states.

Key changes:

- Adds `ValidInt`, `ValidFloat`, and `ValidString` types with set/unset tracking
- Implements JSON and text marshaling interfaces with `omitzero` tag support
- Updates Go version requirement to 1.24.0 for `omitzero` functionality
- Adds testing to CI
- Adds the testifylint linter to our linter config

This change *does not* switch our generator & the linetypes modules to use the new validtypes. That work will come in a follow on PR.
